### PR TITLE
fix token invalidation due to js.php loading

### DIFF
--- a/js/fastupload.js.php
+++ b/js/fastupload.js.php
@@ -1,4 +1,6 @@
 <?php
+if (!defined('NOTOKENRENEWAL'))  define('NOTOKENRENEWAL', 1);
+
 require '../config.php';
 
 $langs->load('fastupload@fastupload');


### PR DESCRIPTION
if you activate the module on a current install of dolibarr 13.x all forms will be broken due to unwanted token renewal

this fixes the problem