### PR TITLE
1.1 fix compatibility concat pdf

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ ___
 
 ## RELEASE 1.1
 
+- FIX : ConcatPdf Compatibility - Admin Page *23/04/2021* - 1.1.2
 - FIX : External access module incompatibility *24/03/2021* - 1.1.1
 - FIX : Mime type error *20/10/2020*
 - NEW : Translation de_DE *20/10/2020*

--- a/class/actions_fastupload.class.php
+++ b/class/actions_fastupload.class.php
@@ -101,6 +101,7 @@ class ActionsFastUpload
 						,fu_method = $("#formuserfile").attr("method")
 						,fu_paramName = $("#formuserfile input[type=file]").attr("name");
 
+					var options = "";
 
 					var dropzone_submit = $("#formuserfile input[type=submit]").parent().clone();
 					$(dropzone_submit).find("input[type=file]").remove();
@@ -126,7 +127,7 @@ class ActionsFastUpload
 		$this->resprints .= '
 
 					var dropzone_form = $("<form id=\'dropzone_form\' action=\'"+fu_action+"\' method=\'"+fu_method+"\' enctype=\'multipart/form-data\'></form>");
-					dropzone_form.append(options);
+					if(options !== "") dropzone_form.append(options);
 					dropzone_form.append(dropzone_div);
 					dropzone_form.append("<br /><div '.(!empty($conf->global->FASTUPLOAD_ENABLE_AUTOUPLOAD) ? 'style=\'display:none;\'' : '').'>"+dropzone_submit+"</div>");
 					if (dropzone_savingdocmask) dropzone_form.append(dropzone_savingdocmask);

--- a/class/actions_fastupload.class.php
+++ b/class/actions_fastupload.class.php
@@ -76,8 +76,11 @@ class ActionsFastUpload
 	{
 		global $conf,$langs;
 
-		if (in_array('externalaccesspage', explode(':', $parameters['context']))){
+		if (in_array('externalaccesspage', explode(':', $parameters['context']))
+			|| (in_array('adminconcatpdf', explode(':', $parameters['context'])) && (float) DOL_VERSION < 12.0)
+		){
 			// n'est pas compatible avec le portail client
+			// ni avec le module concatpdf pour les versions dolibarr inférieures à la 12.0
 			return 0;
 		}
 
@@ -114,9 +117,16 @@ class ActionsFastUpload
 					var dropzone_div = $("<div class=\"dropzone center dz-clickable\"></div>");
 					dropzone_div.append($("<i class=\"upload-icon ace-icon fa fa-cloud-upload blue fa-3x\"></i><br>"));
 					dropzone_div.append($("<span class=\"bigger-150 grey\">'.(addslashes($langs->transnoentities('FastUpload_DefaultMessage'))).'</span>"));
-					dropzone_div.append($("<div id=\"dropzone-previews-box\" class=\"dz dropzone-previews dz-max-files-reached\"></div>"));
+					dropzone_div.append($("<div id=\"dropzone-previews-box\" class=\"dz dropzone-previews dz-max-files-reached\"></div>")); ';
+
+		if(in_array('adminconcatpdf', explode(':', $parameters['context']))) {
+			$this->resprints .= ' var options = "<div>' . preg_replace( "/\r|\n/", "", addslashes($parameters['options'])) . '</div>"';
+		}
+
+		$this->resprints .= '
 
 					var dropzone_form = $("<form id=\'dropzone_form\' action=\'"+fu_action+"\' method=\'"+fu_method+"\' enctype=\'multipart/form-data\'></form>");
+					dropzone_form.append(options);
 					dropzone_form.append(dropzone_div);
 					dropzone_form.append("<br /><div '.(!empty($conf->global->FASTUPLOAD_ENABLE_AUTOUPLOAD) ? 'style=\'display:none;\'' : '').'>"+dropzone_submit+"</div>");
 					if (dropzone_savingdocmask) dropzone_form.append(dropzone_savingdocmask);

--- a/core/modules/modFastUpload.class.php
+++ b/core/modules/modFastUpload.class.php
@@ -61,7 +61,7 @@ class modFastUpload extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module FastUpload";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.1.1';
+		$this->version = '1.1.2';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)


### PR DESCRIPTION
FastUpload ne fonctionnait pas avec ConcatPdf car le formulaire de ConcatPdf a besoin que l'utilisateur précise quel type de document on dépose :  je réaffiche le select options qui a été écrasé par le hook de fastupload.

**/!\ Cette PR ne fonctionne pas tant que la PR standard n'a pas été acceptée** https://github.com/Dolibarr/dolibarr/pull/17381