### PR TITLE
fix return error on hook

### DIFF
--- a/class/actions_fastupload.class.php
+++ b/class/actions_fastupload.class.php
@@ -137,5 +137,6 @@ class ActionsFastUpload
 			$additional = preg_replace('/<script([^>]*)>/', '<script $1 id="fastupload_htmloutput_events">', $additional, 1);
 			echo $additional;
 		}
+		return 0;
 	}
 }


### PR DESCRIPTION
php log shows following issue

`2021-11-05 12:23:50 ERR    Error: Bug into hook showFilesList of module class ActionsFastUpload. Method must not return a string but an int (0=OK, 1=Replace, -1=KO) and set string into ->resprints`